### PR TITLE
Fix typo in projects list

### DIFF
--- a/src/_data/projects.json
+++ b/src/_data/projects.json
@@ -1,7 +1,7 @@
 [
     {
         "title": "A Painting as a Light Switch",
-        "description": "Featuring a Govee Light Curtain, a Raspberry Pi and an Adafruit Capacative Touch Hat",
+        "description": "Featuring a Govee Light Curtain, a Raspberry Pi and an Adafruit Capacitive Touch Hat",
         "thumbnail": "/assets/images/projects/lightwall.jpg",
         "links": [
             {


### PR DESCRIPTION
## Summary
- correct the spelling of "Capacitive" in `projects.json`

## Testing
- `node -e "JSON.parse(require('fs').readFileSync('src/_data/projects.json')) && console.log('OK')"`
