### PR TITLE
Fix active link toggle on project cards

### DIFF
--- a/src/assets/js/main.js
+++ b/src/assets/js/main.js
@@ -10,6 +10,8 @@ document.addEventListener('DOMContentLoaded', () => {
     const projectLinks = document.querySelectorAll('.project-link');
     projectLinks.forEach(link => {
         link.addEventListener('click', () => {
+            // Remove active class from any other project links
+            projectLinks.forEach(l => l.classList.remove('active'));
             link.classList.add('active');
         });
     });


### PR DESCRIPTION
## Summary
- ensure only one project link shows `active` styling by removing the class from other links

## Testing
- `npm test` *(fails: no test specified)*